### PR TITLE
chore(eslint-config-arista-js): update `space-before-function-paren`

### DIFF
--- a/packages/eslint-config-arista-js/index.js
+++ b/packages/eslint-config-arista-js/index.js
@@ -114,7 +114,7 @@ module.exports = {
     'space-before-function-paren': [
       'error',
       {
-        anonymous: 'never',
+        anonymous: 'always',
         asyncArrow: 'always',
         named: 'never',
       },


### PR DESCRIPTION
Always require a space before parens for anonymous functions to match
the new behavior in prettier v2.