### PR TITLE
chore(renovate): enable automerge for dep updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,12 @@
     "schedule:earlyMondays"
   ],
   "assignees": ["rufman"],
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "updateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "branch"
+    }
+  ]
 }


### PR DESCRIPTION
Only open Prs for major version updates, or when some tests fail.