### PR TITLE
chore(eslint-config-arista-ts): upgrade @typescript-eslint packages

### DIFF
--- a/packages/eslint-config-arista-ts/index.js
+++ b/packages/eslint-config-arista-ts/index.js
@@ -14,16 +14,32 @@ module.exports = {
         default: 'array',
       },
     ],
-    '@typescript-eslint/camelcase': [
+    '@typescript-eslint/ban-ts-comment': [
       'error',
       {
-        allow: ['delete_all', 'path_elements'],
+        'ts-ignore': 'allow-with-description',
+        'minimumDescriptionLength': 10,
       },
     ],
     '@typescript-eslint/explicit-function-return-type': [
       'error',
       {
         allowExpressions: true,
+      },
+    ],
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'default',
+        format: ['camelCase'],
+      },
+      {
+        selector: 'property',
+        format: ['camelCase'],
+        filter: {
+          regex: '(delete_all|path_elements)',
+          match: false,
+        },
       },
     ],
     'flowtype/no-types-missing-file-annotation': 0,
@@ -39,7 +55,6 @@ module.exports = {
         jest: true,
       },
       rules: {
-        '@typescript-eslint/ban-ts-ignore': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',
       },
     },

--- a/packages/eslint-config-arista-ts/package-lock.json
+++ b/packages/eslint-config-arista-ts/package-lock.json
@@ -4,6 +4,12 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@arista/prettier-config": {
+			"version": "1.1.3",
+			"resolved": "https://npm.corp.arista.io/@arista%2fprettier-config/-/prettier-config-1.1.3.tgz",
+			"integrity": "sha512-oyjS5UYx/zfmvouhaeRCZKT7hlYP1BQb9TFnSDI3PhEiJtOjlWcQ434TwzspfwFyyTLxhPOMx75ZcWW5yvaYBw==",
+			"dev": true
+		},
 		"@babel/code-frame": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -124,51 +130,59 @@
 		},
 		"@types/eslint-visitor-keys": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+			"resolved": "https://npm.corp.arista.io/@types%2feslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
 			"integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag=="
 		},
 		"@types/json-schema": {
 			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+			"resolved": "https://npm.corp.arista.io/@types%2fjson-schema/-/json-schema-7.0.4.tgz",
 			"integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA=="
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "2.34.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz",
-			"integrity": "sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==",
+			"version": "3.0.2",
+			"resolved": "https://npm.corp.arista.io/@typescript-eslint%2feslint-plugin/-/eslint-plugin-3.0.2.tgz",
+			"integrity": "sha512-ER3bSS/A/pKQT/hjMGCK8UQzlL0yLjuCZ/G8CDFJFVTfl3X65fvq2lNYqOG8JPTfrPa2RULCdwfOyFjZEMNExQ==",
 			"requires": {
-				"@typescript-eslint/experimental-utils": "2.34.0",
+				"@typescript-eslint/experimental-utils": "3.0.2",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.0.0",
+				"semver": "^7.3.2",
 				"tsutils": "^3.17.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://npm.corp.arista.io/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				}
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "2.34.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
-			"integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
+			"version": "3.0.2",
+			"resolved": "https://npm.corp.arista.io/@typescript-eslint%2fexperimental-utils/-/experimental-utils-3.0.2.tgz",
+			"integrity": "sha512-4Wc4EczvoY183SSEnKgqAfkj1eLtRgBQ04AAeG+m4RhTVyaazxc1uI8IHf0qLmu7xXe9j1nn+UoDJjbmGmuqXQ==",
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/typescript-estree": "2.34.0",
+				"@typescript-eslint/typescript-estree": "3.0.2",
 				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^2.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "2.34.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.34.0.tgz",
-			"integrity": "sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==",
+			"version": "3.0.2",
+			"resolved": "https://npm.corp.arista.io/@typescript-eslint%2fparser/-/parser-3.0.2.tgz",
+			"integrity": "sha512-80Z7s83e8QXHNUspqVlWwb4t5gdz/1bBBmafElbK1wwAwiD/yvJsFyHRxlEpNrt4rdK6eB3p+2WEFkEDHAKk9w==",
 			"requires": {
 				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "2.34.0",
-				"@typescript-eslint/typescript-estree": "2.34.0",
+				"@typescript-eslint/experimental-utils": "3.0.2",
+				"@typescript-eslint/typescript-estree": "3.0.2",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "2.34.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
-			"integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
+			"version": "3.0.2",
+			"resolved": "https://npm.corp.arista.io/@typescript-eslint%2ftypescript-estree/-/typescript-estree-3.0.2.tgz",
+			"integrity": "sha512-cs84mxgC9zQ6viV8MEcigfIKQmKtBkZNDYf8Gru2M+MhnA6z9q0NFMZm2IEzKqAwN8lY5mFVd1Z8DiHj6zQ3Tw==",
 			"requires": {
 				"debug": "^4.1.1",
 				"eslint-visitor-keys": "^1.1.0",
@@ -181,7 +195,7 @@
 			"dependencies": {
 				"semver": {
 					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"resolved": "https://npm.corp.arista.io/semver/-/semver-7.3.2.tgz",
 					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				}
 			}
@@ -564,6 +578,30 @@
 				"object.entries": "^1.1.1"
 			}
 		},
+		"eslint-config-arista-js": {
+			"version": "1.1.23",
+			"resolved": "https://npm.corp.arista.io/eslint-config-arista-js/-/eslint-config-arista-js-1.1.23.tgz",
+			"integrity": "sha512-/6WO3t18YcWUFA3OViPqvCbnqnKbFbngAFGs1xDdtw/RaF5xCpTiiUYl7ELn6y11KcCbplmHWVm/EUyJ+hY9kA==",
+			"dev": true,
+			"requires": {
+				"babel-eslint": "10.1.0",
+				"confusing-browser-globals": "1.0.9",
+				"eslint-plugin-arista": "0.1.32",
+				"eslint-plugin-flowtype": "4.7.0",
+				"eslint-plugin-import": "2.20.2"
+			},
+			"dependencies": {
+				"eslint-plugin-flowtype": {
+					"version": "4.7.0",
+					"resolved": "https://npm.corp.arista.io/eslint-plugin-flowtype/-/eslint-plugin-flowtype-4.7.0.tgz",
+					"integrity": "sha512-M+hxhSCk5QBEValO5/UqrS4UunT+MgplIJK5wA1sCtXjzBcZkpTGRwxmLHhGpbHcrmQecgt6ZL/KDdXWqGB7VA==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.15"
+					}
+				}
+			}
+		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
@@ -610,6 +648,15 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
+			}
+		},
+		"eslint-plugin-arista": {
+			"version": "0.1.32",
+			"resolved": "https://npm.corp.arista.io/eslint-plugin-arista/-/eslint-plugin-arista-0.1.32.tgz",
+			"integrity": "sha512-HtBdCsW8MzixBrpfR7IeiEDuFcUrG7zwpWpcEQDaRHpkqssfFui8AF3BfrB8g/diyJuk/4ycqCaaMj+vbVSZBg==",
+			"dev": true,
+			"requires": {
+				"lodash": "4.17.15"
 			}
 		},
 		"eslint-plugin-flowtype": {
@@ -667,7 +714,7 @@
 		},
 		"eslint-utils": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+			"resolved": "https://npm.corp.arista.io/eslint-utils/-/eslint-utils-2.0.0.tgz",
 			"integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
 			"requires": {
 				"eslint-visitor-keys": "^1.1.0"
@@ -1418,7 +1465,7 @@
 		},
 		"regexpp": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+			"resolved": "https://npm.corp.arista.io/regexpp/-/regexpp-3.1.0.tgz",
 			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
 		},
 		"resolve": {
@@ -1738,7 +1785,7 @@
 		},
 		"tsutils": {
 			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+			"resolved": "https://npm.corp.arista.io/tsutils/-/tsutils-3.17.1.tgz",
 			"integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
 			"requires": {
 				"tslib": "^1.8.1"

--- a/packages/eslint-config-arista-ts/package.json
+++ b/packages/eslint-config-arista-ts/package.json
@@ -22,8 +22,8 @@
     "styleguide"
   ],
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "2.34.0",
-    "@typescript-eslint/parser": "2.34.0",
+    "@typescript-eslint/eslint-plugin": "3.0.2",
+    "@typescript-eslint/parser": "3.0.2",
     "eslint-plugin-import": "2.20.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade to the latest versions and update the config to reflect changes
with rules that have been deprecated and replaced.