### PR TITLE
fix(eslint-config-arista-ts): disable camelcase rule

### DIFF
--- a/packages/eslint-config-arista-ts/index.js
+++ b/packages/eslint-config-arista-ts/index.js
@@ -54,6 +54,7 @@ module.exports = {
         },
       },
     ],
+    'camelcase': 'off',
     'flowtype/no-types-missing-file-annotation': 0,
     'import/default': 'off',
     'import/named': 'off',

--- a/packages/eslint-plugin-arista/.eslintrc.json
+++ b/packages/eslint-plugin-arista/.eslintrc.json
@@ -9,12 +9,7 @@
     ],
     "arrow-body-style": "off",
     "arrow-parens": "off",
-    "camelcase": [
-      "error",
-      {
-        "allow": ["delete_all", "path_elements"]
-      }
-    ],
+    "camelcase": "error",
     "class-methods-use-this": "off",
     "curly": ["error", "all"],
     "flowtype/generic-spacing": "off",
@@ -45,7 +40,7 @@
     "import/no-unresolved": "off",
     "import/order": "off",
     "import/prefer-default-export": "off",
-    "indent": "off", // prettier will take care of indentation
+    "indent": "off",
     "max-len": [
       "error",
       {


### PR DESCRIPTION
We're already using @typescript-eslint/naming-convention, so disable the
regular "camelcase" rule.

Update the eslint config for eslint-plugin-arista to get rid of
unnecessary exceptions and make the content proper JSON.