### PR TITLE
fix(eslint-config-arista-ts): allow "ts-expect-error"

### DIFF
--- a/packages/eslint-config-arista-ts/index.js
+++ b/packages/eslint-config-arista-ts/index.js
@@ -17,6 +17,7 @@ module.exports = {
     '@typescript-eslint/ban-ts-comment': [
       'error',
       {
+        'ts-expect-error': 'allow-with-description',
         'ts-ignore': 'allow-with-description',
         'minimumDescriptionLength': 10,
       },


### PR DESCRIPTION
ts-expect-error is useful inside unit tests where TS functions are
intentionally invoked incorrectly. Allow this directive, provided a
description accompanies it.