### PR TITLE
feat(eslint-ts): Add `consistent-type-definitions`

### DIFF
--- a/packages/eslint-config-arista-ts/index.js
+++ b/packages/eslint-config-arista-ts/index.js
@@ -8,12 +8,20 @@ module.exports = {
   },
   plugins: ['@typescript-eslint'],
   rules: {
+    /**
+     * Enforce `T[]` over `Array<T>` usage.
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md
+     */
     '@typescript-eslint/array-type': [
       'error',
       {
         default: 'array',
       },
     ],
+    /**
+     * Manage "@ts-ignore" / "@ts-expect-error" comments.
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-ts-comment.md
+     */
     '@typescript-eslint/ban-ts-comment': [
       'error',
       {
@@ -22,6 +30,10 @@ module.exports = {
         'minimumDescriptionLength': 10,
       },
     ],
+    /**
+     * Ban `object` / `Function` types etc.
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-types.md
+     */
     '@typescript-eslint/ban-types': [
       'error',
       {
@@ -31,12 +43,25 @@ module.exports = {
         },
       },
     ],
+    /**
+     * Enforce `interface` for object definitions.
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-definitions.md
+     */
+    '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
+    /**
+     * Enforce return types for functions.
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+     */
     '@typescript-eslint/explicit-function-return-type': [
       'error',
       {
         allowExpressions: true,
       },
     ],
+    /**
+     * Enforce `public` / `private` / `protected` member accessibility modifiers for classes.
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
+     */
     '@typescript-eslint/explicit-member-accessibility': [
       'error',
       {
@@ -47,6 +72,10 @@ module.exports = {
         },
       },
     ],
+    /**
+     * Enforce variable naming schemes.
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md
+     */
     '@typescript-eslint/naming-convention': [
       'error',
       {
@@ -76,12 +105,41 @@ module.exports = {
         },
       },
     ],
+    /**
+     * Manage usage of the non-null assertion `!`.
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-non-null-assertion.md
+     */
     '@typescript-eslint/no-non-null-assertion': 'off',
+    /**
+     * Enforce camel case naming.
+     * @see https://eslint.org/docs/rules/camelcase
+     */
     'camelcase': 'off',
+    /**
+     * Disallow Flow type imports, aliases, and annotations in files missing a Flow file
+     * declaration.
+     * @see https://github.com/gajus/eslint-plugin-flowtype/blob/master/.README/rules/no-types-missing-file-annotation.md
+     */
     'flowtype/no-types-missing-file-annotation': 0,
+    /**
+     * Enforce default export from import.
+     * @see https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/default.md
+     */
     'import/default': 'off',
+    /**
+     * Enforce named exports from import.
+     * @see https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md
+     */
     'import/named': 'off',
+    /**
+     * Enforce named exports from namespace import (`import * as Namespace from '...'`).
+     * @see https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/namespace.md
+     */
     'import/namespace': 'off',
+    /**
+     * Report use of an exported name as a property on the default export.
+     * @see https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default-member.md
+     */
     'import/no-named-as-default-member': 'off',
   },
   overrides: [
@@ -91,6 +149,10 @@ module.exports = {
         jest: true,
       },
       rules: {
+        /**
+         * Enforce return types for functions.
+         * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+         */
         '@typescript-eslint/explicit-function-return-type': 'off',
       },
     },


### PR DESCRIPTION
Add new rule to enforce "interface" usage over "type"
Add comment descriptions for all rules with links to documentation