### PR TITLE
chore(eslint-config-arista-ts): be more permissive for properties

### DIFF
--- a/packages/eslint-config-arista-ts/index.js
+++ b/packages/eslint-config-arista-ts/index.js
@@ -96,13 +96,9 @@ module.exports = {
         format: ['PascalCase'],
       },
       {
-        // This rule is similar to the old global exception list (which no longer exists)
         selector: 'property',
-        format: null,
-        filter: {
-          regex: '(_skipLogging_|delete_all|path_elements)',
-          match: true,
-        },
+        format: ['camelCase', 'snake_case', 'PascalCase'],
+        leadingUnderscore: 'allow',
       },
     ],
     /**


### PR DESCRIPTION
It's not uncommon for Aeris data to have property names in snake case or
Pascal case, so relax our naming-convention rule to allow these names
without adding exceptions.