### PR TITLE
chore(eslint-config-arista-ts): relax rules for properties a bit more

### DIFF
--- a/packages/eslint-config-arista-ts/index.js
+++ b/packages/eslint-config-arista-ts/index.js
@@ -97,8 +97,9 @@ module.exports = {
       },
       {
         selector: 'property',
-        format: ['camelCase', 'snake_case', 'PascalCase'],
+        format: ['camelCase', 'snake_case', 'PascalCase', 'UPPER_CASE'],
         leadingUnderscore: 'allow',
+        trailingUnderscore: 'allow',
       },
     ],
     /**


### PR DESCRIPTION
Allow UPPER_CASE and trailing underscores as well.