### PR TITLE
fix(eslint-config-arista-js): remove window

### DIFF
--- a/packages/eslint-config-arista-js/index.js
+++ b/packages/eslint-config-arista-js/index.js
@@ -1,6 +1,6 @@
 const confusingBrowserGlobals = require('confusing-browser-globals');
 
-const aristaRestrictedGlobals = ['error', 'isFinite', 'isNaN', 'window'].concat(
+const aristaRestrictedGlobals = ['error', 'isFinite', 'isNaN'].concat(
   confusingBrowserGlobals.filter((value) => value !== 'self'),
 );
 


### PR DESCRIPTION
Remove window from restricted words, since some applications use this
instead of self.