### PR TITLE
fix(eslint-config-arista-js): enable curly rule

### DIFF
--- a/packages/eslint-config-arista-js/index.js
+++ b/packages/eslint-config-arista-js/index.js
@@ -16,6 +16,7 @@ module.exports = {
     'consistent-return': 'error',
     'camelcase': ['error', { allow: ['delete_all', 'path_elements', '^UNSAFE_'] }],
     'constructor-super': 'error',
+    'curly': ['error', 'all'],
     'default-case': 'error',
     'dot-notation': 'error',
     'eqeqeq': ['error', 'always', { null: 'ignore' }],


### PR DESCRIPTION
Enable the curly rule, that disallows single line statements that are
unclear, e.g. single line if statements.